### PR TITLE
a few fixes for @import paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v.1.1.1
+- Fix a crash that occurred in transformer mode in case if the less file imports another one from the same folder
+- Fix incorrect paths in relative imports
+
 ## v.1.1.0 (2017-12-10)
 
 - Less 3.0.0.-alpha.3 code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## v.1.1.1
+## v.1.1.1 (2017-xx-xx)
+
 - Fix a crash that occurred in transformer mode in case if the less file imports another one from the same folder
 - Fix incorrect paths in relative imports
 

--- a/lib/src/environment/abstract_file_manager.dart
+++ b/lib/src/environment/abstract_file_manager.dart
@@ -54,7 +54,7 @@ class AbstractFileManager {
   String getPath(String filename) => pathLib.dirname(filename);
 
   ///
-  /// Normalizes file path (replaces package/ prefix to the absolute path)
+  /// Normalizes file path. Basically does nothing, to be overridden in child managers
   ///
   Future<String> normalizeFilePath(String filename) async => filename;
 

--- a/lib/src/environment/abstract_file_manager.dart
+++ b/lib/src/environment/abstract_file_manager.dart
@@ -156,7 +156,7 @@ class AbstractFileManager {
     }
 
     urlDirectories[urlDirectories.length - 1] = ''; //join must end with '/'
-    return '${"../" * (baseUrlDirectories.length)}${urlDirectories.join("/")}';
+    return '${"../" * (baseUrlDirectories.length - 1)}${urlDirectories.join("/")}';
 
 //2.3.1
 //abstractFileManager.prototype.pathDiff = function pathDiff(url, baseUrl) {

--- a/lib/src/environment/abstract_file_manager.dart
+++ b/lib/src/environment/abstract_file_manager.dart
@@ -146,6 +146,10 @@ class AbstractFileManager {
     final List<String> baseUrlDirectories = baseUrlParts.directories.sublist(i);
     final List<String> urlDirectories = urlParts.directories.sublist(i);
 
+    if (baseUrlDirectories.isEmpty && urlDirectories.isEmpty) {  //both directories are the same
+      return './';
+    }
+
     urlDirectories[urlDirectories.length - 1] = ''; //join must end with '/'
     return '${"../" * (baseUrlDirectories.length - 1)}${urlDirectories.join("/")}';
 

--- a/lib/src/environment/abstract_file_manager.dart
+++ b/lib/src/environment/abstract_file_manager.dart
@@ -53,7 +53,12 @@ class AbstractFileManager {
   ///
   String getPath(String filename) => pathLib.dirname(filename);
 
-//2.3.1
+  ///
+  /// Normalizes file path (replaces package/ prefix to the absolute path)
+  ///
+  Future<String> normalizeFilePath(String filename) async => filename;
+
+  //2.3.1
 //abstractFileManager.prototype.getPath = function (filename) {
 //    var j = filename.lastIndexOf('?');
 //    if (j > 0) {
@@ -151,7 +156,7 @@ class AbstractFileManager {
     }
 
     urlDirectories[urlDirectories.length - 1] = ''; //join must end with '/'
-    return '${"../" * (baseUrlDirectories.length - 1)}${urlDirectories.join("/")}';
+    return '${"../" * (baseUrlDirectories.length)}${urlDirectories.join("/")}';
 
 //2.3.1
 //abstractFileManager.prototype.pathDiff = function pathDiff(url, baseUrl) {

--- a/lib/src/environment/file_file_manager.dart
+++ b/lib/src/environment/file_file_manager.dart
@@ -343,7 +343,7 @@ class FileFileManager extends AbstractFileManager {
       final PackageResolver _resolver = await _packageResolverProvider.getPackageResolver();
       String result = (await _resolver.urlFor(asset.package, asset.path)).toFilePath();
 
-      //urlFor.toFilePath() ignores trailing slash if path is a folder, but it is mandatory to ensure
+      //urlFor.toFilePath() ignores trailing slash if path is a folder, but this slash is mandatory to ensure
       //that pathDiff in AbstractFileManager returns correct result
       if (filename.endsWith('/')) {
         result = '$result/';

--- a/lib/src/environment/file_file_manager.dart
+++ b/lib/src/environment/file_file_manager.dart
@@ -341,7 +341,14 @@ class FileFileManager extends AbstractFileManager {
       }
       final AssetId asset = new AssetId(packageName, pathInPackage);
       final PackageResolver _resolver = await _packageResolverProvider.getPackageResolver();
-      return (await _resolver.urlFor(asset.package, asset.path)).toFilePath();
+      String result = (await _resolver.urlFor(asset.package, asset.path)).toFilePath();
+
+      //urlFor.toFilePath() ignores trailing slash if path is a folder, but it is mandatory to ensure
+      //that pathDiff in AbstractFileManager returns correct result
+      if (filename.endsWith('/')) {
+        result = '$result/';
+      }
+      return result;
     }
     return filename;
   }

--- a/lib/src/environment/file_file_manager.dart
+++ b/lib/src/environment/file_file_manager.dart
@@ -117,7 +117,7 @@ class FileFileManager extends AbstractFileManager {
         throw(fileLoaded.error);
       }
     }
-    final String normalizedFilename = await _normalizeFilePath(_filename);
+    final String normalizedFilename = await normalizeFilePath(_filename);
     final List<String> paths = await _normalizePaths(createListPaths(_filename, currentDirectory, _options));
     final String fullFilename = await findFile(normalizedFilename, paths);
     if (fullFilename != null) {
@@ -327,7 +327,11 @@ class FileFileManager extends AbstractFileManager {
   }
 
   ///
-  Future<String> _normalizeFilePath(String filename) async {
+  /// Normalizes file path (replaces package/ prefix to the absolute path)
+  ///
+
+  @override
+  Future<String> normalizeFilePath(String filename) async {
     final List<String> pathData = pathLib.split(pathLib.normalize(filename));
     if (pathData.length > 1 && pathData.first.startsWith(PACKAGES_PREFIX)) {
       final String packageName = pathData[1];
@@ -346,7 +350,7 @@ class FileFileManager extends AbstractFileManager {
   Future <List<String>> _normalizePaths(List<String> paths) async {
     final List<String> normalizedPaths = <String>[];
     for (String path in paths) {
-      normalizedPaths.add(await _normalizeFilePath(path));
+      normalizedPaths.add(await normalizeFilePath(path));
     }
     return normalizedPaths;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: less_dart
-version: 1.1.0
+version: 1.1.1
 author: Adalberto Lacruz <adalberto.lacruz@gmail.com>
 description: Native Dart Less compiler/transformer to build .css files from .less files.
 homepage: https://github.com/AdalbertoLacruz/less_dart


### PR DESCRIPTION
1. There was a Range Error if one less file imports another one from the same folder (only in transformer mode). Fixed in AbstractFileManager.pathDiff, lines 154-156.

2.  AbstractFileManager.pathDiff worked incorrectly on normalized (from using 'packages' prefix) paths, because folder path did not have a trailing slash after normalization. Fixed in FileFileManager.normalizeFilePath, lines 346-350.

3. If the file1.less imports another file2.less, which contains some relative urls inside, i.e. `background: url(../sample.jpg)`, sometimes these urls were placed incorrectly in resulting file1.css. It happened because these urls also should be normalized, but this step has been missed. Fixed in  ImportManager, line 174, also refactored ImportManager.push() to be async to avoid chains of .then().

@DisDis FYI