### PR TITLE
upgraded build_runner to be Angular 5.3.0 compatible

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 dependencies:
   build: '>=1.0.0 <2.0.0'
-  build_config: '>=0.3.1 <0.4.0'
+  build_config: '>=0.3.1 <=0.4.0'
   meta: '>=1.0.4 <2.0.0'
   mime: '>=0.9.0 <0.12.0'
   package_resolver: ">=1.0.2 < 2.0.0"


### PR DESCRIPTION
I checked the unit tests before and after this minor change, in both cases the same 3 tests were failing, so no regression.