### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/src/environment/url_file_manager.dart
+++ b/lib/src/environment/url_file_manager.dart
@@ -38,7 +38,7 @@ class UrlFileManager extends AbstractFileManager {
         .getUrl(Uri.parse(urlStr))
         .then((HttpClientRequest request) => request.close())
         .then((HttpClientResponse response) {
-          response.transform(utf8.decoder).listen((String contents) {
+          response.cast<List<int>>().transform(utf8.decoder).listen((String contents) {
             dataBuffer.write(contents);
           }, onDone: () {
             if (response.statusCode == 404) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: less_dart
-version: 2.3.0
+version: 2.3.0+1
 author: Adalberto Lacruz <adalberto.lacruz@gmail.com>
 description: Native Dart Less compiler/builder to generate .css files from .less sources.
 homepage: https://github.com/AdalbertoLacruz/less_dart


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900